### PR TITLE
정답 코드를 제출할 때마다 경험치가 올라가는 문제 수정, 등수 로직 수정, 혼자 게임을 시작할 수 있는 문제 수정

### DIFF
--- a/src/main/java/clofi/codeython/member/domain/Member.java
+++ b/src/main/java/clofi/codeython/member/domain/Member.java
@@ -58,7 +58,7 @@ public class Member extends BaseEntity {
         this.nickname = nickname;
     }
 
-    public void gainExp(int gainExp) {
+    public void increaseExp(int gainExp) {
         this.exp += gainExp;
     }
 }

--- a/src/main/java/clofi/codeython/room/domain/Room.java
+++ b/src/main/java/clofi/codeython/room/domain/Room.java
@@ -45,11 +45,14 @@ public class Room {
     @Column(name = "limit_member_cnt", nullable = false)
     private int limitMemberCnt;
 
-    @Column(name = "player_count")
-    private Integer playerCount;
+    @Column(name = "player_count", nullable = false)
+    private int playerCount;
 
     @Column(name = "is_play", nullable = false)
     private boolean isPlay;
+
+    @Column(name = "correct_player_count", nullable = false)
+    private int correctPlayerCount;
 
     public Room(String roomName, Problem problem, int limitMemberCnt, boolean isSecret, String password,
         boolean isSoloPlay, String inviteCode) {
@@ -60,22 +63,26 @@ public class Room {
         this.password = password;
         this.isSoloPlay = isSoloPlay;
         this.inviteCode = inviteCode;
+        this.playerCount = 0;
         this.isPlay = false;
+        this.correctPlayerCount = 0;
     }
 
     public void changeProblem(Problem problem) {
         this.problem = problem;
     }
 
-    public void updatePlayerCount(int playerCount) {
-        this.playerCount = playerCount;
-    }
-
     public void gameEnd() {
         this.isPlay = false;
     }
 
-    public void gameStart() {
+    public void gameStart(int playerCount) {
+        this.playerCount = playerCount;
         this.isPlay = true;
+        this.correctPlayerCount = 0;
+    }
+
+    public void increaseCorrectPlayerCount() {
+        this.correctPlayerCount += 1;
     }
 }

--- a/src/main/java/clofi/codeython/room/domain/RoomMember.java
+++ b/src/main/java/clofi/codeython/room/domain/RoomMember.java
@@ -26,7 +26,13 @@ public class RoomMember {
     private boolean isOwner;
 
     @Column(name = "accuracy")
-    private Integer accuracy;
+    private int accuracy;
+
+    @Column(name = "grade")
+    private int grade;
+
+    @Column(name = "gain_exp")
+    private int gainExp;
 
     public RoomMember(Room room, Member user, boolean isOwner) {
         this.room = room;
@@ -42,7 +48,18 @@ public class RoomMember {
         this.accuracy = Math.max(this.accuracy, accuracy);
     }
 
-    public void accuracyReset() {
+    public void resetGameStatus() {
         this.accuracy = 0;
+        this.grade = 0;
+        this.gainExp = 0;
+    }
+
+    public boolean isAlreadyCorrected() {
+        return this.accuracy == 100;
+    }
+
+    public void updateGradeAndGainExp(int grade, int gainExp) {
+        this.grade = grade;
+        this.gainExp = gainExp;
     }
 }

--- a/src/main/java/clofi/codeython/room/service/RoomService.java
+++ b/src/main/java/clofi/codeython/room/service/RoomService.java
@@ -187,10 +187,12 @@ public class RoomService {
 
     public void gameStart(Long roomId) {
         Room room = roomRepository.findById(roomId).orElseThrow(() -> new IllegalArgumentException("없는 방 번호입니다."));
-        room.gameStart();
         List<RoomMember> roomMembers = roomMemberRepository.findAllByRoom(room);
-        roomMembers.forEach(RoomMember::accuracyReset);
-        room.updatePlayerCount(roomMembers.size());
+        if (roomMembers.size() == 1) {
+            throw new IllegalArgumentException("혼자서 게임을 시작할 수 없습니다.");
+        }
+        room.gameStart(roomMembers.size());
+        roomMembers.forEach(RoomMember::resetGameStatus);
     }
 
     public List<GameEndResponse> getGameResult(Long roomId) {
@@ -204,25 +206,26 @@ public class RoomService {
         List<RoomMember> roomMembers = roomMemberRepository.findAllByRoom(room);
         Problem problem = problemRepository.findByProblemNo(room.getProblem().getProblemNo());
 
-        Integer totalPlayerCount = room.getPlayerCount();
+        int totalPlayerCount = room.getPlayerCount();
         roomMembers.sort((rm1, rm2) -> rm2.getAccuracy() - rm1.getAccuracy());
 
         int preAccuracy = -1;
-        int grade = 1;
+        int grade = room.getCorrectPlayerCount() + 1;
         int tie = 0;
 
         List<GameEndResponse> gameEndResponses = new ArrayList<>();
         for (RoomMember roomMember : roomMembers) {
-            Integer accuracy = roomMember.getAccuracy();
-            if (accuracy == null) {
-                accuracy = 0;
+            if (roomMember.isAlreadyCorrected()) {
+                gameEndResponses.add(new GameEndResponse(roomMember.getUser().getUserNo(), roomMember.getUser().getNickname(), roomMember.getGrade(), roomMember.getGainExp()));
+                continue;
             }
+
+            int accuracy = roomMember.getAccuracy();
             int gainExp = (int) (accuracy * totalPlayerCount * (0.1 - (grade - 1) * 0.02));
             gameEndResponses.add(new GameEndResponse(roomMember.getUser().getUserNo(), roomMember.getUser().getNickname(), grade, gainExp));
-            if (accuracy != 100) {
-                roomMember.getUser().gainExp(gainExp);
-                recordRepository.save(Record.of(roomMember.getUser(), problem, accuracy, grade, room.getPlayerCount()));
-            }
+            roomMember.getUser().increaseExp(gainExp);
+            recordRepository.save(Record.of(roomMember.getUser(), problem, accuracy, grade, room.getPlayerCount()));
+
             if (preAccuracy == roomMember.getAccuracy()) {
                 tie++;
             } else {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 이슈 번호
- issue: #91 
- close: #91 

### 반영 브랜치
ex) feat/#91 -> main

### 변경 사항
- [x] 정답 코드를 이미 제출한 이력이 있으면, 경험치를 증가시키지 않게 변경하기
- [x] 등수를 RoomMember를 기준으로 계산하지 않고, 정답 코드를 제출한 인원을 기준으로 계산하기
- [x] 혼자 게임을 시작하면, 오류를 던지게 변경 

### 테스트 결과
<img width="345" alt="image" src="https://github.com/Clo-fi/Codeython-server/assets/145690963/bb5cd829-1472-4044-b4cf-47f0b59554a2">
